### PR TITLE
Create season and week

### DIFF
--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,0 +1,3 @@
+class Season < ActiveRecord::Base
+  validates :start_date, presence: true, uniqueness: true
+end

--- a/app/models/week.rb
+++ b/app/models/week.rb
@@ -1,0 +1,3 @@
+class Week < ActiveRecord::Base
+  validates :start_date, presence: true, uniqueness: true
+end

--- a/db/migrate/20160127035213_create_seasons.rb
+++ b/db/migrate/20160127035213_create_seasons.rb
@@ -1,0 +1,7 @@
+class CreateSeasons < ActiveRecord::Migration
+  def change
+    create_table :seasons do |t|
+      t.date :start_date, null: false
+    end
+  end
+end

--- a/db/migrate/20160127035213_create_seasons.rb
+++ b/db/migrate/20160127035213_create_seasons.rb
@@ -1,7 +1,7 @@
 class CreateSeasons < ActiveRecord::Migration
   def change
     create_table :seasons do |t|
-      t.date :start_date, null: false
+      t.datetime :start_date, null: false
     end
   end
 end

--- a/db/migrate/20160127035545_create_weeks.rb
+++ b/db/migrate/20160127035545_create_weeks.rb
@@ -1,0 +1,7 @@
+class CreateWeeks < ActiveRecord::Migration
+  def change
+    create_table :weeks do |t|
+      t.date :start_date, null: false
+    end
+  end
+end

--- a/db/migrate/20160127035545_create_weeks.rb
+++ b/db/migrate/20160127035545_create_weeks.rb
@@ -1,7 +1,7 @@
 class CreateWeeks < ActiveRecord::Migration
   def change
     create_table :weeks do |t|
-      t.date :start_date, null: false
+      t.datetime :start_date, null: false
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160120011152) do
+ActiveRecord::Schema.define(version: 20160127035545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "seasons", force: :cascade do |t|
+    t.date "start_date", null: false
+  end
 
   create_table "teams", force: :cascade do |t|
     t.string   "name",       null: false
@@ -37,5 +41,9 @@ ActiveRecord::Schema.define(version: 20160120011152) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
+
+  create_table "weeks", force: :cascade do |t|
+    t.date "start_date", null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 20160127035545) do
   enable_extension "plpgsql"
 
   create_table "seasons", force: :cascade do |t|
-    t.date "start_date", null: false
+    t.datetime "start_date", null: false
   end
 
   create_table "teams", force: :cascade do |t|
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20160127035545) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   create_table "weeks", force: :cascade do |t|
-    t.date "start_date", null: false
+    t.datetime "start_date", null: false
   end
 
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :team do
     sequence(:name) { |n| "Patriots#{n}" }
-    city "New England"
+    location "New England"
   end
 end

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe Season do
+  subject { Season.new(start_date: '2016-01-26') }
+
+  it { should validate_presence_of(:start_date) }
+  it { should validate_uniqueness_of(:start_date) }
+end

--- a/spec/models/week_spec.rb
+++ b/spec/models/week_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe Week do
+  subject { Week.new(start_date: '2016-01-26') }
+
+  it { should validate_presence_of(:start_date) }
+  it { should validate_uniqueness_of(:start_date) }
+end


### PR DESCRIPTION
Quick little PR.

Was no sure if I should use `date` or `datetime` for `Week.start_date`. My concern is if a game runs past midnight at the end of the week, then it's now in the following week. I realize at this stage of the app there is no issues with this, but thinking down the line.... should `Week.start_time` be a `datetime` attribute type? I currently have it set to be a `date` attribute since `Season.start_time` is a date field.
